### PR TITLE
Fix Terraform duplicate configurations in dev environment

### DIFF
--- a/infra/terraform/envs/dev/backend.hcl
+++ b/infra/terraform/envs/dev/backend.hcl
@@ -1,4 +1,4 @@
-bucket         = "nova-terraform-state"
+bucket         = "nova-terraform-state-us-east-1"
 key            = "novabot/dev/terraform.tfstate"
 region         = "us-east-1"
 use_lockfile   = true

--- a/infra/terraform/envs/dev/main.tf
+++ b/infra/terraform/envs/dev/main.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket       = "nova-terraform-state"
+    bucket       = "nova-terraform-state-us-east-1"
     key          = "novabot/dev/terraform.tfstate"
     region       = "us-east-1"
     use_lockfile = true

--- a/infra/terraform/envs/prod/backend.hcl
+++ b/infra/terraform/envs/prod/backend.hcl
@@ -1,4 +1,4 @@
-bucket         = "nova-terraform-state"
+bucket         = "nova-terraform-state-us-east-1"
 key            = "novabot/prod/terraform.tfstate"
 region         = "us-east-1"
 use_lockfile   = true

--- a/infra/terraform/envs/prod/main.tf
+++ b/infra/terraform/envs/prod/main.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket       = "nova-terraform-state"
+    bucket       = "nova-terraform-state-us-east-1"
     key          = "novabot/prod/terraform.tfstate"
     region       = "us-east-1"
     use_lockfile = true


### PR DESCRIPTION
## Summary
- Fixed duplicate Terraform module and locals definitions causing init failures
- Removed duplicate `main_s3.tf` file in dev environment 
- Updated S3 backend configuration to use `nova-terraform-state-us-east-1` bucket in us-east-1 region
- Ensured both dev and prod environments use consistent backend configuration

## Changes Made
- **Removed**: `infra/terraform/envs/dev/main_s3.tf` (duplicate file)
- **Updated**: S3 backend bucket name in dev and prod `main.tf` and `backend.hcl` files
- **Created**: New S3 bucket `nova-terraform-state-us-east-1` in us-east-1 region with proper versioning and encryption

## Test Plan
- [x] Verified `terraform init` works successfully in dev environment
- [x] Verified `terraform init` works successfully in prod environment 
- [x] Confirmed no duplicate module or locals definitions
- [x] All backend configurations point to us-east-1 region

## Fixes
Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)