### PR TITLE
Implement nova-aicoe.com domain configuration for all environments

### DIFF
--- a/infra/terraform/envs/dev/main.tf
+++ b/infra/terraform/envs/dev/main.tf
@@ -91,9 +91,26 @@ module "api_gateway" {
   environment                      = var.environment
   project_name                     = var.project_name
   invoke_agent_lambda_function_arn = module.lambda_invoke_agent.function_arn
+  domain_name                      = var.api_domain_name
+  certificate_arn                  = var.certificate_arn
+  enable_custom_domain             = var.enable_custom_domain
   tags                           = local.common_tags
   
   depends_on = [module.lambda_invoke_agent]
+}
+
+# Lambda permission for API Gateway (after both are created)
+resource "aws_lambda_permission" "allow_api_gateway_invoke_agent" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda_invoke_agent.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${module.api_gateway.execution_arn}/*/*"
+
+  depends_on = [
+    module.api_gateway,
+    module.lambda_invoke_agent
+  ]
 }
 
 # Amazon Connect Scaffold (Optional)

--- a/infra/terraform/envs/dev/terraform.tfvars.example
+++ b/infra/terraform/envs/dev/terraform.tfvars.example
@@ -12,6 +12,11 @@ bedrock_agent_model = "anthropic.claude-3-sonnet-20240229-v1:0"
 # S3 Configuration (leave empty to auto-generate bucket name)
 knowledge_base_s3_bucket = ""
 
+# Domain Configuration
+api_domain_name = "dev.nova-aicoe.com"
+certificate_arn = ""  # ARN of SSL certificate for nova-aicoe.com
+enable_custom_domain = false  # Set to true when certificate is available
+
 # Additional Tags
 tags = {
   Owner       = "your-team"

--- a/infra/terraform/envs/dev/variables.tf
+++ b/infra/terraform/envs/dev/variables.tf
@@ -39,3 +39,21 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "api_domain_name" {
+  description = "Custom domain name for the API Gateway"
+  type        = string
+  default     = "dev.nova-aicoe.com"
+}
+
+variable "certificate_arn" {
+  description = "ARN of the SSL certificate for the custom domain"
+  type        = string
+  default     = ""
+}
+
+variable "enable_custom_domain" {
+  description = "Whether to enable custom domain for API Gateway"
+  type        = bool
+  default     = false
+}

--- a/infra/terraform/envs/prod/main.tf
+++ b/infra/terraform/envs/prod/main.tf
@@ -91,9 +91,26 @@ module "api_gateway" {
   environment                      = var.environment
   project_name                     = var.project_name
   invoke_agent_lambda_function_arn = module.lambda_invoke_agent.function_arn
+  domain_name                      = var.api_domain_name
+  certificate_arn                  = var.certificate_arn
+  enable_custom_domain             = var.enable_custom_domain
   tags                           = local.common_tags
   
   depends_on = [module.lambda_invoke_agent]
+}
+
+# Lambda permission for API Gateway (after both are created)
+resource "aws_lambda_permission" "allow_api_gateway_invoke_agent" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda_invoke_agent.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${module.api_gateway.execution_arn}/*/*"
+
+  depends_on = [
+    module.api_gateway,
+    module.lambda_invoke_agent
+  ]
 }
 
 # Amazon Connect Scaffold (Optional)

--- a/infra/terraform/envs/prod/terraform.tfvars.example
+++ b/infra/terraform/envs/prod/terraform.tfvars.example
@@ -12,6 +12,11 @@ bedrock_agent_model = "anthropic.claude-3-sonnet-20240229-v1:0"
 # S3 Configuration (leave empty to auto-generate bucket name)
 knowledge_base_s3_bucket = ""
 
+# Domain Configuration
+api_domain_name = "prod.nova-aicoe.com"
+certificate_arn = ""  # ARN of SSL certificate for nova-aicoe.com
+enable_custom_domain = false  # Set to true when certificate is available
+
 # Additional Tags
 tags = {
   Owner       = "your-team"

--- a/infra/terraform/envs/prod/variables.tf
+++ b/infra/terraform/envs/prod/variables.tf
@@ -39,3 +39,21 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "api_domain_name" {
+  description = "Custom domain name for the API Gateway"
+  type        = string
+  default     = "prod.nova-aicoe.com"
+}
+
+variable "certificate_arn" {
+  description = "ARN of the SSL certificate for the custom domain"
+  type        = string
+  default     = ""
+}
+
+variable "enable_custom_domain" {
+  description = "Whether to enable custom domain for API Gateway"
+  type        = bool
+  default     = false
+}

--- a/infra/terraform/modules/api_gateway_invoke_agent/main.tf
+++ b/infra/terraform/modules/api_gateway_invoke_agent/main.tf
@@ -260,24 +260,27 @@ resource "aws_api_gateway_usage_plan_key" "chatbot_usage_plan_key" {
   usage_plan_id = aws_api_gateway_usage_plan.chatbot_usage_plan[0].id
 }
 
-# Domain Name (optional - for custom domain)
-# Uncomment and configure if custom domain is needed
-# resource "aws_apigatewayv2_domain_name" "chatbot_domain" {
-#   domain_name = "api.novabot.example.com"
-#   
-#   domain_name_configuration {
-#     certificate_arn = aws_acm_certificate.api_cert.arn
-#     endpoint_type   = "REGIONAL"
-#     security_policy = "TLS_1_2"
-#   }
-# }
+# Domain Name for custom domain
+resource "aws_apigatewayv2_domain_name" "chatbot_domain" {
+  count       = var.enable_custom_domain ? 1 : 0
+  domain_name = var.domain_name
+  
+  domain_name_configuration {
+    certificate_arn = var.certificate_arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+
+  tags = var.tags
+}
 
 # API Mapping for custom domain
-# resource "aws_apigatewayv2_api_mapping" "chatbot_mapping" {
-#   api_id      = aws_apigatewayv2_api.chatbot_api.id
-#   domain_name = aws_apigatewayv2_domain_name.chatbot_domain.id
-#   stage       = aws_apigatewayv2_stage.api_stage.id
-# }
+resource "aws_apigatewayv2_api_mapping" "chatbot_mapping" {
+  count       = var.enable_custom_domain ? 1 : 0
+  api_id      = aws_apigatewayv2_api.chatbot_api.id
+  domain_name = aws_apigatewayv2_domain_name.chatbot_domain[0].id
+  stage       = aws_apigatewayv2_stage.api_stage.id
+}
 
 # WAF Web ACL (optional)
 resource "aws_wafv2_web_acl" "chatbot_waf" {

--- a/infra/terraform/modules/api_gateway_invoke_agent/outputs.tf
+++ b/infra/terraform/modules/api_gateway_invoke_agent/outputs.tf
@@ -85,3 +85,13 @@ output "cors_configuration" {
     ]
   }
 }
+
+output "custom_domain_name" {
+  description = "Custom domain name (if enabled)"
+  value       = var.enable_custom_domain ? var.domain_name : null
+}
+
+output "custom_domain_target" {
+  description = "Target domain name for custom domain (if enabled)"
+  value       = var.enable_custom_domain ? aws_apigatewayv2_domain_name.chatbot_domain[0].domain_name_configuration[0].target_domain_name : null
+}

--- a/infra/terraform/modules/api_gateway_invoke_agent/variables.tf
+++ b/infra/terraform/modules/api_gateway_invoke_agent/variables.tf
@@ -48,3 +48,21 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "domain_name" {
+  description = "Custom domain name for the API Gateway"
+  type        = string
+  default     = ""
+}
+
+variable "certificate_arn" {
+  description = "ARN of the SSL certificate for the custom domain"
+  type        = string
+  default     = ""
+}
+
+variable "enable_custom_domain" {
+  description = "Whether to enable custom domain for API Gateway"
+  type        = bool
+  default     = false
+}

--- a/infra/terraform/modules/lambda_invoke_agent/main.tf
+++ b/infra/terraform/modules/lambda_invoke_agent/main.tf
@@ -93,7 +93,7 @@ resource "aws_lambda_function" "invoke_agent" {
   environment {
     variables = {
       NODE_ENV                = var.environment
-      AWS_REGION              = data.aws_region.current.name
+      AWS_REGION              = data.aws_region.current.id
       LOG_LEVEL               = var.environment == "prod" ? "info" : "debug"
       BEDROCK_AGENT_ID        = var.bedrock_agent_id
       BEDROCK_AGENT_ALIAS_ID  = var.bedrock_agent_alias_id
@@ -134,6 +134,7 @@ resource "aws_sqs_queue" "invoke_agent_dlq" {
 
 # Lambda permission for API Gateway to invoke
 resource "aws_lambda_permission" "allow_api_gateway" {
+  count         = var.api_gateway_execution_arn != "" ? 1 : 0
   statement_id  = "AllowExecutionFromAPIGateway"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.invoke_agent.function_name


### PR DESCRIPTION
## Summary
Implements support for the nova-aicoe.com domain as requested in issue #3, with environment-specific subdomains for both dev and prod environments.

## Changes Made

### Domain Configuration
- **Dev Environment**: `dev.nova-aicoe.com`
- **Prod Environment**: `prod.nova-aicoe.com`
- Added SSL certificate support for custom domains
- Made domain configuration optional (disabled by default)

### Technical Implementation
- **API Gateway Module**: Added domain variables and conditional domain resources
- **Environment Variables**: Added domain configuration variables to both dev and prod
- **SSL Support**: Added certificate_arn variable for SSL configuration
- **Dependency Management**: Fixed API Gateway Lambda permission dependencies

### Configuration Files Updated
- `infra/terraform/modules/api_gateway_invoke_agent/variables.tf` - Added domain variables
- `infra/terraform/modules/api_gateway_invoke_agent/main.tf` - Implemented conditional domain resources
- `infra/terraform/modules/api_gateway_invoke_agent/outputs.tf` - Added domain outputs
- `infra/terraform/envs/dev/variables.tf` - Added dev domain variables (default: dev.nova-aicoe.com)
- `infra/terraform/envs/prod/variables.tf` - Added prod domain variables (default: prod.nova-aicoe.com)
- Updated terraform.tfvars.example files with domain configuration examples

## Usage Instructions

### To Enable Custom Domain:
1. Obtain SSL certificate for `*.nova-aicoe.com` in AWS Certificate Manager
2. Set the certificate ARN in `certificate_arn` variable
3. Set `enable_custom_domain = true`
4. Run `terraform apply`

### Default Configuration:
- Custom domain is **disabled by default**
- API Gateway will use AWS-generated domain names until custom domain is enabled
- Domain names are pre-configured but certificate_arn must be provided

## Test Plan
- [x] Terraform validate passes for both dev and prod environments
- [x] Configuration is backwards compatible (no breaking changes)
- [x] Domain resources are only created when `enable_custom_domain = true`
- [x] Fixed Lambda permission dependency issues

## Notes
- The Route 53 hosted zone for nova-aicoe.com should be configured separately
- SSL certificates need to be obtained in AWS Certificate Manager before enabling
- Once enabled, DNS records need to be updated to point to the API Gateway domain

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)